### PR TITLE
Leaflet update 1.7.1 to 1.9.4

### DIFF
--- a/Interactive_Maps.html
+++ b/Interactive_Maps.html
@@ -13,15 +13,15 @@
     <link rel="stylesheet" href="print.css" media="print"  />
 
     <script src='https://api.mapbox.com/mapbox.js/v3.3.1/mapbox.js'></script>
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.0/dist/leaflet.css" crossorigin=""/>
-	<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" crossorigin=""></script>   
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"/>
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin=""/>
+	<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>   
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.css"/>
 	<script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol/dist/L.Control.Locate.min.js" charset="utf-8"></script>
 
     <script src="javascripts/leaflet.easyPrint.js"></script>   
 	<script src="javascripts/privatepaths.js"></script>
-	<script src="javascripts/nordicPaths.js"></script>
+	<script src="javascripts/nordicpaths.js"></script>
 	<script src="javascripts/trailreport.js"></script>   
 
     <link rel="icon" sizes="196x196" type="image/png" href="/images/GTN-green-196.png" >
@@ -444,7 +444,7 @@
     var legend = L.control({position: 'topleft'});
     legend.onAdd = function (map) {
         var div = L.DomUtil.create('div', 'info legend');
-        div.innerHTML  = '<div class="leaflet-touch"><div class="leaflet-bar"><a class="leaflet-bar-part leaflet-bar-part-single" title="Send a trail status email" href="javascript:confirmTrailReport();" style="outline: currentcolor none medium;"><img src="images/email.jpg"></a></div></div>';
+        div.innerHTML  = '<div class="leaflet-touch"><div class="leaflet-bar"><a class="leaflet-bar-part leaflet-bar-part-single" title="Send a trail status email" href="javascript:confirmTrailReport();" style="outline: currentcolor none medium;"><i class="fa fa-envelope" style="font-size: 16px; line-height: 26px;"></i></a></div></div>';
         return div;
     };
     legend.addTo(map);
@@ -456,7 +456,7 @@
   	check('motioncheck',lc.options.showCompass);
    	check('accuracycheck',lc.options.locateOptions.enableHighAccuracy);
  	
-	map.addEventListener('mousemove', function(ev) {lat = ev.latlng.lat; lng = ev.latlng.lng;});
+	map.addEventListener('pointermove', function(ev) {lat = ev.latlng.lat; lng = ev.latlng.lng;});
 
 	document.getElementById("map").addEventListener("contextmenu", function (event) {
     	// Prevent the browser's context menu from appearing

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ This is the website for the [ Groton Trails Network at www.grotontrails.org](htt
 ### Development 
 
 The site is 100% static and is very easy to change. 
-1. Make a local clone using git or github. Github has lots of documentation on how to do this. 
+1. Make a local clone using git or github. [Github has lots of documentation](https://docs.github.com/en/get-started/start-your-journey/hello-world) on how to do this. 
 2. Run a local webserver. Many web servers will work.
-	1. For windows the [MiniWeb HTTP server](https://sourceforge.net/projects/miniweb/) works nicely. 
+	1. For Windows the [MiniWeb HTTP server](https://sourceforge.net/projects/miniweb/) 
 	2. Run the following command "miniweb.exe -r ..\grotontrails.github.io"
-3. Commit and submit a pull request.
+  3. For Mac/Linux/Windows, `python -m http.server` or `python3 -m http.server 9000` 
+3. Create a new git branch `git checkout -b feature-update-etc`
+4. Commit and submit a pull request.
 
 It is hosted directly by github, using the github pages feature, with a https proxy run by Cloadflare. Once the pull request is accepted, it is live. 
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ This is the website for the [ Groton Trails Network at www.grotontrails.org](htt
 The site is 100% static and is very easy to change. 
 1. Make a local clone using git or github. [Github has lots of documentation](https://docs.github.com/en/get-started/start-your-journey/hello-world) on how to do this. 
 2. Run a local webserver. Many web servers will work.
-	1. For Windows the [MiniWeb HTTP server](https://sourceforge.net/projects/miniweb/) 
-	2. Run the following command "miniweb.exe -r ..\grotontrails.github.io"
-  3. For Mac/Linux/Windows, `python -m http.server` or `python3 -m http.server 9000` 
+	- For Windows the [MiniWeb HTTP server](https://sourceforge.net/projects/miniweb/), work nicely. Run the following command `miniweb.exe -r ..\grotontrails.github.io`- You can use Python's built-in HTTP on Mac/Linux/Windows `python -m http.server` or `python3 -m http.server 9000`
+
 3. Create a new git branch `git checkout -b feature-update-etc`
 4. Commit and submit a pull request.
 


### PR DESCRIPTION
:wave: love the map!

## Changes
- Upgrades Leaflet to use [latest stable 1.9.4](https://leafletjs.com/2022/09/21/leaflet-1.9.0.html)
- Tested locally added python simple https server documentation
- Changes loading font awesome to use https://www.jsdelivr.com/ with integrity check. 
  -  Bootstrap has transitioned from using MaxCDN to jsDelivr as its primary CDN provider.
- Updated email icon as rendering on mobile caused original error I noticed
- NorticPath.js loading failed as case sensitive 
- Update Deprecated `mousemove` JS with `pointermove` for tablets etc
